### PR TITLE
Improve setup.py

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,7 @@
 *.exe
 *.out
 *.app
+
+# LibTorch
+libtorch.zip
+GodotModule/libtorch

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ def install_module(godot_root, rewrite=False):
 def install_python_module():
 	current_path = os.getcwd()
 	os.chdir('PythonModule')
-	os.system('python setup.py install')
+	os.system('python setup.py install --user')
 	os.chdir(current_path)
 
 if __name__=='__main__':

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ def download_unpack(rewrite=False):
 	# url = 'https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.7.0.zip'
 	url = 'https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.7.0%2Bcpu.zip'
 	if (not Path('libtorch.zip').exists()) or rewrite:
+		rmtree('GodotModule/libtorch')
 		print('Downloading libtorch')
 		filedata = request.urlopen(url)
 		datatowrite = filedata.read()

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 import os
 import sys
 import argparse
-from shutil import copyfile, copytree, rmtree
+from shutil import copyfile, copytree, rmtree, which
 from urllib import request
 from zipfile import ZipFile
 from pathlib import Path
@@ -44,7 +44,10 @@ def install_module(godot_root, rewrite=False):
 def install_python_module():
 	current_path = os.getcwd()
 	os.chdir('PythonModule')
-	os.system('python setup.py install --user')
+	python_command = 'python'
+	if which(python_command) is None:
+		python_command += '3'
+	os.system(python_command + ' setup.py install --user')
 	os.chdir(current_path)
 
 if __name__=='__main__':

--- a/setup.py
+++ b/setup.py
@@ -12,15 +12,15 @@ def download_unpack(rewrite=False):
 	# url = 'https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.7.0.zip'
 	url = 'https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.7.0%2Bcpu.zip'
 	if (not Path('libtorch.zip').exists()) or rewrite:
-		libtorch_path = 'GodotModule/libtorch'
-		if Path(libtorch_path).exists():
-			rmtree(libtorch_path)
-		
 		print('Downloading libtorch')
 		filedata = request.urlopen(url)
 		datatowrite = filedata.read()
 		with open('libtorch.zip', 'wb') as f:
 			f.write(datatowrite)
+
+	libtorch_path = 'GodotModule/libtorch'
+	if Path(libtorch_path).exists():
+		rmtree(libtorch_path)
 
 	print('Extracting libtorch')
 	with ZipFile('libtorch.zip', 'r') as zipObj:

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,10 @@ def download_unpack(rewrite=False):
 	# url = 'https://download.pytorch.org/libtorch/cu102/libtorch-cxx11-abi-shared-with-deps-1.7.0.zip'
 	url = 'https://download.pytorch.org/libtorch/cpu/libtorch-cxx11-abi-shared-with-deps-1.7.0%2Bcpu.zip'
 	if (not Path('libtorch.zip').exists()) or rewrite:
-		rmtree('GodotModule/libtorch')
+		libtorch_path = 'GodotModule/libtorch'
+		if Path(libtorch_path).exists():
+			rmtree(libtorch_path)
+		
 		print('Downloading libtorch')
 		filedata = request.urlopen(url)
 		datatowrite = filedata.read()

--- a/setup.py
+++ b/setup.py
@@ -19,10 +19,9 @@ def download_unpack(rewrite=False):
 		with open('libtorch.zip', 'wb') as f:
 			f.write(datatowrite)
 
-	if (not Path('GodotModule/libtorch').exists()) or rewrite:
-		print('Extracting libtorch')
-		with ZipFile('libtorch.zip', 'r') as zipObj:
-   			zipObj.extractall(path='GodotModule')
+	print('Extracting libtorch')
+	with ZipFile('libtorch.zip', 'r') as zipObj:
+		zipObj.extractall(path='GodotModule')
 	
 
 def compile_godot(godot_root, platform='x11', tools='yes', target='release_debug', bits=64):


### PR DESCRIPTION
I ran into some issues when trying to set this up on my machine so I made some changes to the setup.py in order to make this more accessible to new users. The changes include:

- Always delete the libtorch folder and extract libtorch.zip. I had the problem that the setup.py failed silently after cleaning the git repository since there was an empty libtorch folder. This lead to libtorch.zip not being extracted. This is fixed by deleting the folder each time setup.py runs. Also this makes sure there are no old files left in case the value of url was changed. I think the few seconds needed to extract the file is nothing compared to how long this script runs.
- On some operating systems python is not available but is called python3 so I added a check for that.
- Install the python module as user because it would fail without sudo.
- Added libtorch to gitignore because this was showing up as 1000+ untracked files.